### PR TITLE
Replace rse-tre references/urls with uktre

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ You can find all [emoji/Type keywords](https://allcontributors.org/docs/en/emoji
 To add a contributor, comment on Issue or Pull Request (where the contributor is involved) using this message for @all-contributors:
 `@all-contributors please add @<username> for <keyword in the Type column>`
 
-Whatever your availability, there is a way to contribute to the RSE TRE repo!
+Whatever your availability, there is a way to contribute to the UK-TRE repo!
 
 ## 👋 I'm busy, I only have 5 minutes
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 RSE TRE
+Copyright (c) 2022-2023 UK TRE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
-# Research Software Engineers Trusted Research Environment Working Group (RSETREWG)
+# UK Trusted Research Environment Working Group (UK-TRE)
 
-[![Build](https://github.com/manics/rse-tre/actions/workflows/build.yml/badge.svg)](https://github.com/manics/rse-tre/actions/workflows/build.yml)
-[![Documentation Status](https://readthedocs.org/projects/rse-tre-community/badge/?version=latest)](https://rse-tre-community.readthedocs.io/en/latest/?badge=latest)
+[![Build](https://github.com/uk-tre/website/actions/workflows/build.yml/badge.svg)](https://github.com/uk-tre/website/actions/workflows/build.yml)
+[![Documentation Status](https://readthedocs.org/projects/uktre/badge/?version=latest)](https://uktre.readthedocs.io/en/latest/?badge=latest)
 
-https://rse-tre-community.readthedocs.io/
+https://uktre.readthedocs.io/
 
-# :wave: Welcome to the RSE TRE WG repo!
+# :wave: Welcome to the UK-TRE website repo!
 
-This repo is for Research Software Engineers (RSEs), researchers, Trusted Research Environment (TRE) users, developers and enthusiasts to collaborate on and communicate about open-source TRE infrastructure.
+# Join the Community
 
-Our [Code of Conduct](CODE_OF_CONDUCT.md) applies to all interactions within this space. We value the participation of every member of the community and want to ensure that everybody has an enjoyable and fulfilling experience.
+The UK-TRE community is open to anyone with an interest in Trusted Research Environments, including researchers, operators, information governors and managers and more, from all sectors and disciplines.
 
-We want this space to be community-driven, and not have any one voice direct conversation. Please use it as a free-form place to share thoughts and ideas, work together on resolving problems, and discuss where the community should be focusing our efforts!
+UK-TRE aims to encourage open collaborations and sharing of innovative ideas to support the delivery of groundbreaking research with sensitive data across the UK and beyond.
+
+This repository is for the UK-TRE community website hosted on Read the Docs https://uktre.readthedocs.io/
+
+## How to join
+
+Anyone can join our mailing list and attend our meetings, you do not need to provide any information other than your email address.
+
+:Mailing list: https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=RSE-TRE-COMM&A=1
+:Slack channel: https://ukrse.slack.com/archives/C045ETUPPD0
 
 # :family: Community and Support
 
-- Visit [our readthedocs site](https://rse-tre-community.readthedocs.io/en/latest/index.html#) to see latest developments with the community
-- Join the `rse-tre-wg` [Slack channel](https://ukrse.slack.com/archives/C045ETUPPD0) in the RSE Slack Workspace.
-- Look through our [issues on GitHub](https://github.com/rse-tre/community/issues) to see what we're working on, and create a new issue if you have something to add!
+- Visit [our readthedocs site](https://uktre.readthedocs.io/en/latest/index.html) to see latest developments with the community
+- Look through our [issues on GitHub](https://github.com/uktre/website/issues) to see what we're working on, and create a new issue if you have something to add!
 
 # :handshake: Contributing
 
@@ -26,14 +34,9 @@ There are lots of ways to contribute, not just writing docs!
 
 See our [Code of Conduct](CODE_OF_CONDUCT.md) and our [Contributor Guide](CONTRIBUTING.md) to learn more about how we work together as a community and how you can contribute.
 
-# :link: Useful links
-
-- [Our readthedocs site](https://rse-tre-community.readthedocs.io/en/latest/index.html#)
-- [The report from our latest meeting](https://rse-tre-community.readthedocs.io/en/latest/events/wg_workshops/rsecon22/index.html)
-
 ## :computer: Building the docs
 
-This repository is published using [Read the Docs](https://rse-tre-community.readthedocs.io/).
+This repository is published using [Read the Docs](https://uktre.readthedocs.io/).
 The documentation is built with Sphinx, and written in [Markdown with the MyST Parser](https://myst-parser.readthedocs.io/).
 
 To build this repository locally, create a Python environment and install the requirements:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,9 +6,9 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "RSE TRE"
-copyright = "2022, RSE TRE"
-author = "RSE TRE"
+project = "UK TRE"
+copyright = "2022, UK TRE"
+author = "UK TRE"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/events/wg_workshops/2022-12-05-december-meeting/index.md
+++ b/docs/events/wg_workshops/2022-12-05-december-meeting/index.md
@@ -21,8 +21,8 @@ Date: Monday 5th December 2022
 ## Useful links
 
 - **Slack channel**: https://ukrse.slack.com/archives/C045ETUPPD0
-- **RSECON Report (foundational event)**: https://rse-tre-community.readthedocs.io/en/latest/events/wg_workshops/rsecon22/index.html
-- **Community GitHub**: https://github.com/rse-tre/community
+- **RSECON Report (foundational event)**: https://uktre.readthedocs.io/en/latest/events/wg_workshops/rsecon22/index.html
+- **Community GitHub**: https://github.com/uk-tre/website
 
 ## Schedule
 
@@ -197,7 +197,7 @@ Each of the 3 working groups updated us on their progress.
 
 ### Community management
 
-- [GitHub repository](https://github.com/rse-tre/community) and associated [ReadTheDocs site](https://rse-tre-community.readthedocs.io/) up and running. [Notes from first meeting](https://rse-tre-community.readthedocs.io/en/latest/events/wg_workshops/rsecon22/index.html) posted on ReadTheDocs site.
+- [GitHub repository](https://github.com/uk-tre/website) and associated [ReadTheDocs site](https://uktre.readthedocs.io/) up and running. [Notes from first meeting](https://uktre.readthedocs.io/en/latest/events/wg_workshops/rsecon22/index.html) posted on ReadTheDocs site.
 - [Slack channel](https://ukrse.slack.com/archives/C045ETUPPD0) up and running. Mailing lis to come.
 - [Newcastle Commitment](https://docs.google.com/document/d/1F8TOilZlu0k8dojFFqbD-GuIyJIjCMCMhscJTEz7yKQ/edit): Principles for the community
 - Question: Should we require/allow people to sign the commitment? A: Seems to be a consensus to allow people to sign the commitment but not require it.

--- a/docs/events/wg_workshops/2023-03-29-march-meeting/index.md
+++ b/docs/events/wg_workshops/2023-03-29-march-meeting/index.md
@@ -20,9 +20,9 @@ breakout-tre-architectures
 
 - **JISC Mailing list**: https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=RSE-TRE-COMM&A=1
 - **Slack channel**: https://ukrse.slack.com/archives/C045ETUPPD0
-- **Report from last meeting**: https://rse-tre-community.readthedocs.io/en/latest/events/wg_workshops/2022-12-05-december-meeting/index.html
-- **Newcaslte Committment**: https://rse-tre-community.readthedocs.io/en/latest/newcastle-commitment/index.html
-- **Community GitHub**: https://github.com/rse-tre/community
+- **Report from last meeting**: https://uktre.readthedocs.io/en/latest/events/wg_workshops/2022-12-05-december-meeting/index.html
+- **Newcaslte Committment**: https://uktre.readthedocs.io/en/latest/newcastle-commitment/index.html
+- **Community GitHub**: https://github.com/uk-tre/website
 
 ## Schedule
 
@@ -52,7 +52,7 @@ breakout-tre-architectures
 
 Hari Sood from the Alan Turing Institute kicked off proceedings with the reminder that this is an open, self-organised community and is still in its infancy. Everyone is welcome - folk building and running TREs, folk using TREs, folk just interested in them. The group has a strong focus on open source TREs but anyone involved in non-open TREs is, of course, also welcome. A plea to all: please do suggest things we should be doing together, and any thoughts you have on how best we can work.
 
-[The Newcastle Commitment](https://rse-tre-community.readthedocs.io/en/latest/newcastle-commitment/index.html) is our public statement of intent as a community.
+[The Newcastle Commitment](https://uktre.readthedocs.io/en/latest/newcastle-commitment/index.html) is our public statement of intent as a community.
 
 Currently the group has quarterly meetings, three virtual and one in-person / hybrid at the RSE Conference each September. We have also set up four working groups to help us co-ordinate work between the quarterly meetings:
 

--- a/docs/events/wg_workshops/2023-06-28-june-meeting/index.md
+++ b/docs/events/wg_workshops/2023-06-28-june-meeting/index.md
@@ -21,11 +21,11 @@ breakout-federation-standards
 
 - **JISC Mailing list**: https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=RSE-TRE-COMM&A=1
 - **Slack channel**: https://ukrse.slack.com/archives/C045ETUPPD0
-- **Report from last meeting**: https://rse-tre-community.readthedocs.io/en/latest/events/wg_workshops/2023-03-29-march-meeting/index.html
-- **Newcastle Commitment**: https://rse-tre-community.readthedocs.io/en/latest/newcastle-commitment/index.html
-- **Community GitHub**: https://github.com/rse-tre/community
+- **Report from last meeting**: https://uktre.readthedocs.io/en/latest/events/wg_workshops/2023-03-29-march-meeting/index.html
+- **Newcastle Commitment**: https://uktre.readthedocs.io/en/latest/newcastle-commitment/index.html
+- **Community GitHub**: https://github.com/uk-tre/website
 - **Mentimeter**: https://www.menti.com/algf3akq4q6g
-- **Read the docs**: https://rse-tre-community.readthedocs.io/en/latest/structure/index.html
+- **Read the docs**: https://uktre.readthedocs.io/en/latest/structure/index.html
 
 ## Schedule
 

--- a/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
+++ b/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
@@ -42,5 +42,5 @@ The meeting is free to attend and lunch is included!
 
 :JISC Mailing list: https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=RSE-TRE-COMM&A=1
 :Slack channel: https://ukrse.slack.com/archives/C045ETUPPD0
-:Report from last meeting: https://rse-tre-community.readthedocs.io/en/latest/events/wg_workshops/2023-03-29-march-meeting/index.html
-:Community website: https://rse-tre-community.readthedocs.io/
+:Report from last meeting: https://uktre.readthedocs.io/en/latest/events/wg_workshops/2023-03-29-march-meeting/index.html
+:Community website: https://uktre.readthedocs.io/

--- a/docs/structure/community-management.md
+++ b/docs/structure/community-management.md
@@ -3,7 +3,7 @@
 ## Summary
 
 - The Trusted Research Environment (TRE) Community Management and Engagement arm of the UK TRE Community aims to foster collaboration and facilitate the sharing and distribution of innovative ideas to support the success of all participants.
-- We steer the wider group in alignment with the principles of the [Newcastle Commitment](https://github.com/rse-tre/community/blob/main/docs/newcastle-commitment/index.md), working together to create a more secure, robust, and capable infrastructure, leading to enhanced research outcomes.
+- We steer the wider group in alignment with the principles of the [Newcastle Commitment](https://github.com/uk-tre/website/blob/main/docs/newcastle-commitment/index.md), working together to create a more secure, robust, and capable infrastructure, leading to enhanced research outcomes.
 - We operate as a volunteer-based, community-driven initiative under the umbrella of the DARE UK Community Group relying on the expertise and resources contributed by our members from UK universities, research institutions, and other relevant bodies.
 
 ## Focus Areas

--- a/docs/structure/open-source-open-standards.md
+++ b/docs/structure/open-source-open-standards.md
@@ -4,7 +4,7 @@
 
 The open-source and open-standards TRE working group promotes the development and use of open standards and open infrastructure for secure environments.
 
-This includes supporting the community in developing and maintaining open-standards, and providing a forum for open-source TRE contributors to meet and share ideas, in-line with the principles of the [Newcastle Commitment](https://github.com/rse-tre/community/blob/main/docs/newcastle-commitment/index.md).
+This includes supporting the community in developing and maintaining open-standards, and providing a forum for open-source TRE contributors to meet and share ideas, in-line with the principles of the [Newcastle Commitment](https://github.com/uk-tre/website/blob/main/docs/newcastle-commitment/index.md).
 
 ## Focus Areas
 


### PR DESCRIPTION
There were some old references to RSE-TRE left behind, especially in the README which I've rewritten.