### PR TITLE
Add provisional schedule for Swansea 2023 meeting

### DIFF
--- a/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
+++ b/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
@@ -40,7 +40,7 @@ This meeting is open to everyone and free to attend, thanks to the sponsorship b
   - Arrival
 - - 10:15 - 10:30
   - Welcome and introductions
-- - 10:30 - 11:13
+- - 10:30 - 11:15
   - Keynote from Emily Jefferson (CTO, HDR UK) including discussion
 - - **11:15 - 11:30**
   - **Break**

--- a/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
+++ b/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
@@ -48,11 +48,11 @@ This meeting is open to everyone and free to attend, thanks to the sponsorship b
   - Lightning talks
 - - **12:45 - 14:00**
   - **Lunch**
-- - 14:00 - 16:30
+- - 14:00 - 16:45
   - Parallel sessions/breakouts, including breaks. <!--See &lt;todo&gt; for topics-->
-- - 16:30 - 17:00
-  - Wrap-up of parallel sessions/breakouts
-- - 17:00 - 17:30
+- - 16:45 - 17:15
+  - Conclusions, actions and next steps
+- - 17:15 - 17:30
   - Closing remarks
 
 ```

--- a/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
+++ b/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
@@ -26,7 +26,7 @@ The meeting is open to everyone, and will be attended by a range of stakeholders
 
 The day will feature lightning talks from cross-sector research industry teams who are at the forefront of testing innovative ideas for TREs, and a keynote presentation on HDR UK’s plans for the tech eco-system.
 
-However, the most important part of the day will be breakout sessions and discussions where we will take advantage of the mix of sectors and stakeholders to learn from each other, evaluate the work already done, and define goals for the community and the future provision of TREs in the UK and beyond over the next few years.
+A key part of the day will be breakout sessions and discussions where we will take advantage of the mix of sectors and stakeholders to learn from each other, evaluate the work already done, and define goals for the community and the future provision of TREs in the UK and beyond over the next few years.
 
 This meeting is open to everyone and free to attend, thanks to the sponsorship by The Alan Turing Institute, HDR UK and DARE UK. The morning talks will also be broadcast online for those that cannot attend in person, but all afternoon sessions including breakout discussions will be in-person only.
 

--- a/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
+++ b/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
@@ -30,7 +30,32 @@ However, the most important part of the day will be breakout sessions and discus
 
 This meeting is open to everyone and free to attend, thanks to the sponsorship by The Alan Turing Institute, HDR UK and DARE UK. The morning talks will also be broadcast online for those that cannot attend in person, but all afternoon sessions including breakout discussions will be in-person only.
 
-**Full agenda coming soon**
+#### Provisional schedule
+
+```{list-table}
+:widths: 100 300
+:header-rows: 0
+
+- - 10:00 - 10:15
+  - Arrival
+- - 10:15 - 10:30
+  - Welcome and introductions
+- - 10:30 - 11:13
+  - Keynote from Emily Jefferson (CTO, HDR UK) including discussion
+- - **11:15 - 11:30**
+  - **Break**
+- - 11:30 - 12:45
+  - Lightning talks
+- - **12:45 - 14:00**
+  - **Lunch**
+- - 14:00 - 16:30
+  - Parallel sessions/breakouts, including breaks. <!--See &lt;todo&gt; for topics-->
+- - 16:30 - 17:00
+  - Wrap-up of parallel sessions/breakouts
+- - 17:00 - 17:30
+  - Closing remarks
+
+```
 
 ### Registration
 


### PR DESCRIPTION
If everyone's happy with the rest of the timings we can fill in the `14:00 - 16:30  Parallel sessions/breakouts, including breaks` with potential topics later.