### PR TITLE
Update footer to new mailing list

### DIFF
--- a/docs/_templates/footer-links.html
+++ b/docs/_templates/footer-links.html
@@ -1,4 +1,4 @@
-<a href="https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=RSE-TRE-COMM&A=1"
+<a href="https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=UK-TRE-COMM&A=1"
   ><i class="fa-solid fa-envelope"></i> Mailing list</a
 ><br />
 <a href="https://ukrse.slack.com/archives/C045ETUPPD0"


### PR DESCRIPTION
Just noticed the website footer still links to the old mailing list RSE-TRE-COMM instead of UK-TRE-COMM