### PR TITLE
Add placeholder events for future 2024 meetings

### DIFF
--- a/docs/events/wg_workshops/2024-03-14-march-meeting/index.md
+++ b/docs/events/wg_workshops/2024-03-14-march-meeting/index.md
@@ -1,0 +1,16 @@
+# Provisional: UK TRE Community meeting - March 2024
+
+:Provisional Date: [Thursday 14th March 2024](https://arewemeetingyet.com/London/2024-03-14/00:00/UK%20TRE%20Community%20meeting)
+:Time: To be decided
+:Registration: Opening soon!
+:Location: Online
+
+## Background
+
+## Agenda
+
+### Keynote
+
+### Community updates
+
+### Breakout sessions

--- a/docs/events/wg_workshops/2024-06-05-june-meeting/index.md
+++ b/docs/events/wg_workshops/2024-06-05-june-meeting/index.md
@@ -1,0 +1,16 @@
+# Provisional: UK TRE Community meeting - June 2024
+
+:Provisional Date: [Wednesday 5th June 2024](https://arewemeetingyet.com/London/2024-06-05/00:00/UK%20TRE%20Community%20meeting)
+:Time: To be decided
+:Registration: Will open after the March 2024 meeting
+:Location: Online
+
+## Background
+
+## Agenda
+
+### Keynote
+
+### Community updates
+
+### Breakout sessions

--- a/docs/events/wg_workshops/2024-09-02-september-meeting/index.md
+++ b/docs/events/wg_workshops/2024-09-02-september-meeting/index.md
@@ -1,0 +1,16 @@
+# Provisional: UK TRE Community meeting - September 2024
+
+:Provisional Date: [Monday 2nd September 2024](https://arewemeetingyet.com/London/2024-09-02/00:00/UK%20TRE%20Community%20meeting)
+:Time: To be decided
+:Registration: Will open after the June 2024 meeting
+:Location: Hopefully in person at [RSECon24](https://rsecon24.society-rse.org/) and online
+
+## Background
+
+## Agenda
+
+### Keynote
+
+### Community updates
+
+### Breakout sessions

--- a/docs/events/wg_workshops/2024-12-10-december-meeting/index.md
+++ b/docs/events/wg_workshops/2024-12-10-december-meeting/index.md
@@ -1,0 +1,16 @@
+# Provisional: UK TRE Community meeting - June 2024
+
+:Provisional Date: [Tuesday 3rd December 2024](https://arewemeetingyet.com/London/2024-12-03/00:00/UK%20TRE%20Community%20meeting)
+:Time: To be decided
+:Registration: Will open after the September 2024 meeting
+:Location: Online
+
+## Background
+
+## Agenda
+
+### Keynote
+
+### Community updates
+
+### Breakout sessions

--- a/docs/events/wg_workshops/2024-12-10-december-meeting/index.md
+++ b/docs/events/wg_workshops/2024-12-10-december-meeting/index.md
@@ -1,4 +1,4 @@
-# Provisional: UK TRE Community meeting - June 2024
+# Provisional: UK TRE Community meeting - December 2024
 
 :Provisional Date: [Tuesday 3rd December 2024](https://arewemeetingyet.com/London/2024-12-03/00:00/UK%20TRE%20Community%20meeting)
 :Time: To be decided

--- a/docs/events/wg_workshops/index.md
+++ b/docs/events/wg_workshops/index.md
@@ -1,5 +1,19 @@
 # Community Workshops
 
+## Planned meetings
+
+```{toctree}
+:maxdepth: 1
+
+2024-03-14-march-meeting/index
+2024-06-05-june-meeting/index
+2024-09-02-september-meeting/index
+2024-12-10-december-meeting/index
+
+```
+
+## Previous meetings
+
 ```{toctree}
 :maxdepth: 1
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,10 +10,10 @@ background/index
 structure/index
 ```
 
-```{admonition} UK-TRE December 2023 meeting
+```{admonition} UK-TRE March 2024 meeting
 :class: attention
 
-The [UK-TRE December 2023 meeting](events/wg_workshops/2023-12-05-december-meeting/index) will be held online on Monday 5th December 2023.
+The [UK-TRE March 2024 meeting](events/wg_workshops/2024-03-14-march-meeting/index) is provisionally organised for Thursday 14th March 2024. More details soon!
 ```
 
 Welcome to the site! This site containts resources, reports, meeting notes, discussions and more associated with the UK Trusted Research Environment Community.


### PR DESCRIPTION
Add placeholder dates from https://github.com/uk-tre/community-management/issues/16

These dates may be changed based on community feedback if there are significant clashing events.