### PR TITLE
Fix build warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 myst_enable_extensions = ["fieldlist", "linkify"]
 myst_linkify_fuzzy_links = False
 
+# Automatically create anchors for in-page headings up to level 3
+myst_heading_anchors = 4
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
+++ b/docs/events/wg_workshops/2023-09-04-september-meeting/index.md
@@ -41,7 +41,7 @@ This report summarises the sessions of the day, as laid out in the schedule belo
 Recordings of the morning session, including the Welcome, Keynote, and Lightning Talks, are [available on YouTube](https://www.youtube.com/channel/UCd7AZjyH33aCmIojGHMfqEg).
 More detail of the breakout sessions can be found in their respective notes from the day, which are linked in each summary below.
 
-#### Schedule
+### Schedule
 
 ```{list-table}
 :widths: 100 300

--- a/docs/events/wg_workshops/2023-12-05-december-meeting/discussion-ppie.md
+++ b/docs/events/wg_workshops/2023-12-05-december-meeting/discussion-ppie.md
@@ -2,12 +2,12 @@
 
 **Chairs**: Tudor Besleaga (Sector Health Ltd), Claire Macdonald (Manchester University NHS Foundation Trust)
 
-### Useful reading:
+## Useful reading:
 
 - [Consensus Statement on Public Involvement and Engagement with Data Intensive Health Research](https://ijpds.org/article/view/586/2829)
 - [Goldacre Review](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1067053/goldacre-review-using-health-data-for-research-and-analysis.pdf) - Chapter 5 Information Governance, Ethics and Participation
 
-### Prompts
+## Prompts
 
 The need to conduct PPIE is well-recognised by the health research community at large, but how can we run it effectively?
 There will be a brief presentation on public expectations from using personal health data for research.


### PR DESCRIPTION
There are several build warnings which are currently ignored. This fixes them, and ensures future PRs will need to be free of warnings before merging.